### PR TITLE
Disable gifs (for now!) and memory reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rayimg
 
-rayimg is a lightweight image viewer designed to run on Raspberry Pis. It has a slideshow mode and displays via the Direct Rendering Manager (DRM) on a Raspberry Pi, so X/Wayland are not needed - this makes it nice to run on a lightweight OS! Check out my other project [PiSlide OS](https://github.com/JarvyJ/pislide-os) if interested. It supports many image formats, including more modern ones: JPG, PNG, GIF (animated!), WEBP, AVIF, JXL, HEIF, HEIC, SVG, BMP, TIFF, and QOI.
+rayimg is a lightweight image viewer designed to run on Raspberry Pis. It has a slideshow mode and displays via the Direct Rendering Manager (DRM) on a Raspberry Pi, so X/Wayland are not needed - this makes it nice to run on a lightweight OS! Check out my other project [PiSlide OS](https://github.com/JarvyJ/pislide-os) if interested. It supports many image formats, including more modern ones: JPG, PNG, WEBP, AVIF, JXL, HEIF, HEIC, SVG, BMP, TIFF, and QOI.
 
 It has been built and tested on a Pi 0W, Pi 3, and Pi 4.
 
@@ -9,14 +9,43 @@ rayimg is _not currently available_ as a binary. It's mostly created to be used 
 
 ## Features
 - Modern and common image formats!
+- Arrow Key Navigation
 - Load images from the commandline: `rayimg some-folder/image.jxl`
 - Load an entire folder of images and navigate with arrow keys: `rayimg some-folder`
   - or recurse into sub folders `rayimg --recursive some-folder`
 - Sorting files in a folder `rayimg --sort random some-folder`
 - Support for automatically transitioning between images `rayimg --duration 3 some-folder`
   - with a cool cross-dissolve effect: `rayimg --duration 3 --transition-duration 2 some-folder`
+- Support for displaying filenames or captions on screen `rayimg --display filename`
+  - A captions for `example.jpg` would be next to it as  `example.jpg.txt` and can be displayed with `rayimg --display caption`
 
 all flags and their options can be found with `rayimg --help`.
+
+## Loading via ini files
+When passing in a single folder, rayimg can load settings via a `slide_settings.ini` file that lives in that folder:
+Example `slide_settings.ini`:
+```ini
+# duration to show each slide in seconds
+Duration = 7
+
+# how long the crossfade should happen
+# can set to 0 to disable fade
+TransitionDuration = 3
+
+# set to true (without quotes) if there are sub-folders in this directory that have images to display
+Recursive = false
+
+# can be "none", "filename", or "caption" to display various text over the images
+# a "caption" is simply the exact filename (including extension) with .txt on the end
+# ex: The caption for bird.jpg would be in bird.jpg.txt
+Display = "none"
+
+# can be "filename", "natural", or "random"
+# "natural" sorts mostly alphabetically, but tries to handle numbers correctly.
+# Ex "filename": f-1.jpg, f-10.jpg, f-2.jpg
+# Ex "natural": f-1.jpg, f-2.jpg, f-10.jpg
+Sort = "natural"
+```
 
 ## How it works
 rayimg uses [raylib](https://www.raylib.com/) for rendering images on-screen, and support for some image formats. The more modern formats are supported via [libvips](https://www.libvips.org/).

--- a/cmd/rayimg/main.go
+++ b/cmd/rayimg/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/JarvyJ/rayimg/internal/fileloader"
 	"github.com/JarvyJ/rayimg/internal/font"
 	"github.com/JarvyJ/rayimg/internal/imageloader"
+	"github.com/davidbyttow/govips/v2/vips"
 
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
@@ -253,6 +254,8 @@ func main() {
 	}
 
 	rl.CloseWindow()
+
+	vips.Shutdown()
 }
 
 func createTextureFromImage(texture *rl.Texture2D) (rl.Vector2, float32) {

--- a/cmd/rayimg/main.go
+++ b/cmd/rayimg/main.go
@@ -100,14 +100,14 @@ func main() {
 	fontPosition := rl.NewVector2(20, float32(screenHeight)-float32(fontSize)-10)
 	rl.SetTextureFilter(font.Texture, rl.FilterBilinear)
 
-	img := imageloader.GetCurrentImage(&imageLoader)
+	img := imageLoader.GetCurrentImage()
 	position, scale := createTextureFromImage(img.ImageData)
 
 	var nextImg *imageloader.RayImgImage
 	nextPosition, nextScale := rl.Vector2{}, float32(0)
 
 	if args.TransitionDuration > 0 {
-		nextImg = imageloader.PeekNextImage(&imageLoader)
+		nextImg = imageLoader.PeekNextImage()
 		nextPosition, nextScale = createTextureFromImage(nextImg.ImageData)
 	}
 
@@ -130,13 +130,13 @@ func main() {
 		switch args.Display {
 		case "filename":
 			rl.DrawRectangleGradientV(0, int32(fontPosition.Y)-int32(fontSize), screenWidth, int32(fontSize)*2+20, color.RGBA{0, 0, 0, 0}, color.RGBA{0, 0, 0, 192})
-			rl.DrawTextEx(font, imageloader.GetCurrentFilename(&imageLoader), fontPosition, float32(font.BaseSize), 0, rl.RayWhite)
+			rl.DrawTextEx(font, imageLoader.GetCurrentFilename(), fontPosition, float32(font.BaseSize), 0, rl.RayWhite)
 
 		case "caption":
-			caption := imageloader.GetCurrentCaption(&imageLoader)
+			caption := imageLoader.GetCurrentCaption()
 			if len(caption) > 0 {
 				rl.DrawRectangleGradientV(0, int32(fontPosition.Y)-int32(fontSize), screenWidth, int32(fontSize)*2+20, color.RGBA{0, 0, 0, 0}, color.RGBA{0, 0, 0, 192})
-				rl.DrawTextEx(font, imageloader.GetCurrentCaption(&imageLoader), fontPosition, float32(font.BaseSize), 0, rl.RayWhite)
+				rl.DrawTextEx(font, imageLoader.GetCurrentCaption(), fontPosition, float32(font.BaseSize), 0, rl.RayWhite)
 			}
 		}
 	}
@@ -151,7 +151,7 @@ func main() {
 	var unloadSingleTextureAndDrawNewImage = func() {
 		rl.UnloadTexture(*img.ImageData)
 
-		img = imageloader.GetCurrentImage(&imageLoader)
+		img = imageLoader.GetCurrentImage()
 		position, scale = createTextureFromImage(img.ImageData)
 
 		transitionTime = 0
@@ -170,11 +170,11 @@ func main() {
 	var unloadCurrentTextureAndDrawNewImage = func() {
 		rl.UnloadTexture(*img.ImageData)
 
-		imageloader.IncreaseCurrentIndex(&imageLoader)
+		imageLoader.IncreaseCurrentIndex()
 		img = nextImg
 		position, scale = nextPosition, nextScale
 
-		nextImg = imageloader.PeekNextImage(&imageLoader)
+		nextImg = imageLoader.PeekNextImage()
 		nextPosition, nextScale = createTextureFromImage(nextImg.ImageData)
 
 		transitioning = false
@@ -194,12 +194,12 @@ func main() {
 	for !rl.WindowShouldClose() {
 
 		if rl.IsKeyPressed(rl.KeyRight) {
-			imageloader.IncreaseCurrentIndex(&imageLoader)
+			imageLoader.IncreaseCurrentIndex()
 			unloadSingleTextureAndDrawNewImage()
 		}
 
 		if rl.IsKeyPressed(rl.KeyLeft) {
-			imageloader.DecreaseCurrentIndex(&imageLoader)
+			imageLoader.DecreaseCurrentIndex()
 			unloadSingleTextureAndDrawNewImage()
 		}
 
@@ -213,7 +213,7 @@ func main() {
 		if transitioning {
 			transitionTime = transitionTime + float64(rl.GetFrameTime())
 			if args.TransitionDuration == 0 {
-				imageloader.IncreaseCurrentIndex(&imageLoader)
+				imageLoader.IncreaseCurrentIndex()
 				unloadSingleTextureAndDrawNewImage()
 			} else {
 				opacity := 255.0 * (transitionTime / args.TransitionDuration)
@@ -233,7 +233,7 @@ func main() {
 			// wildest/best/dumbest hack ever
 			// basically make raylib wait the right time each frame in the gif
 			rl.SetTargetFPS(int32(100 / img.GifData.Delay[animationCurrentFrame]))
-			rl.UpdateTexture(*img.ImageData, imageloader.GetGifFrame(img.GifData, animationCurrentFrame))
+			rl.UpdateTexture(*img.ImageData, img.GifData.GetGifFrame(animationCurrentFrame))
 
 			animationCurrentFrame = animationCurrentFrame + 1
 			if animationCurrentFrame >= len(img.GifData.Delay) {

--- a/cmd/rayimg/main.go
+++ b/cmd/rayimg/main.go
@@ -89,7 +89,14 @@ func main() {
 	}
 	imageLoader := imageloader.New(listOfFiles, screenWidth, screenHeight)
 
-	// i'm avoiding intializing the screen until, so if there are any errors, you don't get a flash of a window
+	vips.LoggingSettings(nil, vips.LogLevelWarning)
+	vipsConfig := vips.Config{}
+	// disable vips cache, we aren't doing/redoing many operations in a row
+	// Also, i've seen rayimg get OOM-killed, so less memory use is better
+	vipsConfig.MaxCacheSize = 0
+	vips.Startup(&vipsConfig)
+
+	// i'm avoiding intializing the screen until now, so if there are any errors, you don't get a flash of a window
 	rl.SetTraceLogLevel(rl.LogWarning)
 	rl.SetConfigFlags(rl.FlagVsyncHint)
 	rl.InitWindow(screenWidth, screenHeight, "rayimg - Image Viewer")

--- a/internal/fileloader/fileloader.go
+++ b/internal/fileloader/fileloader.go
@@ -13,7 +13,7 @@ import (
 	"github.com/JarvyJ/rayimg/internal/arguments"
 )
 
-var validFileExtensions = []string{".jpg", ".png", ".jpeg", ".webp", ".gif", ".avif", ".jxl", ".heif", ".heic", ".svg", ".bmp", ".tiff", ".tif", ".qoi"}
+var validFileExtensions = []string{".jpg", ".png", ".jpeg", ".webp", ".avif", ".jxl", ".heif", ".heic", ".svg", ".bmp", ".tiff", ".tif", ".qoi"}
 var validFileExtensionsSet = make(map[string]bool)
 
 func validFileByExtension(path string) bool {

--- a/internal/imageloader/gif.go
+++ b/internal/imageloader/gif.go
@@ -22,7 +22,7 @@ type GifData struct {
 }
 
 func newGifData(r *os.File, currentFile string, img *image.RGBA) *GifData {
-	gifData := &GifData{}
+	gifData := GifData{}
 
 	r.Seek(0, 0)
 	gif, err := gif.DecodeAll(r)
@@ -42,7 +42,7 @@ func newGifData(r *os.File, currentFile string, img *image.RGBA) *GifData {
 	// }
 
 	gifData.Delay = gif.Delay
-	return gifData
+	return &gifData
 }
 
 func loadGif(r *os.File, currentFile string, imageData *RayImgImage) error {
@@ -66,7 +66,7 @@ func loadGif(r *os.File, currentFile string, imageData *RayImgImage) error {
 
 // use previous frame's value if outside rect and continue
 // if the new pixels are transparent, use the previous frame's value
-func GetGifFrame(gifData *GifData, currentFrame int) []color.RGBA {
+func (gifData *GifData) GetGifFrame(currentFrame int) []color.RGBA {
 	if len(gifData.ImagesData[currentFrame]) == 0 {
 		gifData.ImagesData[currentFrame] = make([]color.RGBA, len(gifData.ImagesData[currentFrame-1]))
 		copy(gifData.ImagesData[currentFrame], gifData.ImagesData[currentFrame-1])

--- a/internal/imageloader/imageloader.go
+++ b/internal/imageloader/imageloader.go
@@ -31,8 +31,11 @@ func New(listOfFiles []string, screenWidth int32, screenHeight int32) ImageLoade
 	imageLoader.cacheDirectory, imageLoader.cacheImages = os.LookupEnv("CACHE_DIR")
 
 	vips.LoggingSettings(nil, vips.LogLevelWarning)
-	vips.Startup(nil)
-	// replace with finalizer: defer vips.Shutdown()
+	vipsConfig := vips.Config{}
+	// disable vips cache, we aren't doing/redoing many operations in a row
+	// Also, i've seen rayimg get OOM-killed, so less memory use is better
+	vipsConfig.MaxCacheSize = 0
+	vips.Startup(&vipsConfig)
 
 	return imageLoader
 }

--- a/internal/imageloader/imageloader.go
+++ b/internal/imageloader/imageloader.go
@@ -21,7 +21,7 @@ type ImageLoader struct {
 	cacheDirectory string
 }
 
-func New(listOfFiles []string, screenWidth int32, screenHeight int32) ImageLoader {
+func New(listOfFiles []string, screenWidth int32, screenHeight int32) *ImageLoader {
 	imageLoader := ImageLoader{}
 	imageLoader.listOfFiles = listOfFiles
 	imageLoader.currentIndex = 0
@@ -37,7 +37,7 @@ func New(listOfFiles []string, screenWidth int32, screenHeight int32) ImageLoade
 	vipsConfig.MaxCacheSize = 0
 	vips.Startup(&vipsConfig)
 
-	return imageLoader
+	return &imageLoader
 }
 
 // a little hacky, but it should work for now.
@@ -48,30 +48,30 @@ type RayImgImage struct {
 	GifData     *GifData
 }
 
-func deleteImageAtIndex(imageLoader *ImageLoader, index int) {
+func (imageLoader *ImageLoader) deleteImageAtIndex(index int) {
 	imageLoader.listOfFiles = slices.Delete(imageLoader.listOfFiles, index, index+1)
 	numberOfFiles := len(imageLoader.listOfFiles)
 	if numberOfFiles == 0 {
 		panic("Could not open any of the found files. See above in log for details. Images potentially corrupt or incompatible formats")
 	}
 	imageLoader.currentIndex = imageLoader.currentIndex - 1
-	IncreaseCurrentIndex(imageLoader)
+	imageLoader.IncreaseCurrentIndex()
 }
 
-func GetCurrentImage(imageLoader *ImageLoader) *RayImgImage {
+func (imageLoader *ImageLoader) GetCurrentImage() *RayImgImage {
 	start := time.Now()
-	rayimage := getImage(imageLoader, imageLoader.currentIndex)
+	rayimage := imageLoader.getImage(imageLoader.currentIndex)
 	fmt.Println("Time to decode: ", time.Now().Sub(start), imageLoader.listOfFiles[imageLoader.currentIndex])
 	return rayimage
 }
 
-func GetCurrentFilename(imageLoader *ImageLoader) string {
+func (imageLoader *ImageLoader) GetCurrentFilename() string {
 	filePath := imageLoader.listOfFiles[imageLoader.currentIndex]
 	splitPath := strings.Split(filePath, "/")
 	return splitPath[len(splitPath)-1]
 }
 
-func GetCurrentCaption(imageLoader *ImageLoader) string {
+func (imageLoader *ImageLoader) GetCurrentCaption() string {
 	filePath := imageLoader.listOfFiles[imageLoader.currentIndex]
 	captionPath := filePath + ".txt"
 	captionData, err := os.ReadFile(captionPath)
@@ -81,7 +81,7 @@ func GetCurrentCaption(imageLoader *ImageLoader) string {
 	return strings.TrimSpace(string(captionData))
 }
 
-func IncreaseCurrentIndex(imageLoader *ImageLoader) {
+func (imageLoader *ImageLoader) IncreaseCurrentIndex() {
 	numberOfFiles := len(imageLoader.listOfFiles)
 	if imageLoader.currentIndex+1 >= numberOfFiles {
 		imageLoader.currentIndex = 0
@@ -90,7 +90,7 @@ func IncreaseCurrentIndex(imageLoader *ImageLoader) {
 	}
 }
 
-func DecreaseCurrentIndex(imageLoader *ImageLoader) {
+func (imageLoader *ImageLoader) DecreaseCurrentIndex() {
 	if imageLoader.currentIndex <= 0 {
 		imageLoader.currentIndex = len(imageLoader.listOfFiles) - 1
 	} else {
@@ -98,22 +98,22 @@ func DecreaseCurrentIndex(imageLoader *ImageLoader) {
 	}
 }
 
-func PeekNextImage(imageLoader *ImageLoader) *RayImgImage {
+func (imageLoader *ImageLoader) PeekNextImage() *RayImgImage {
 	nextImageIndex := imageLoader.currentIndex + 1
 	numberOfFiles := len(imageLoader.listOfFiles)
 	if nextImageIndex >= numberOfFiles {
 		nextImageIndex = 0
 	}
 	start := time.Now()
-	img := getImage(imageLoader, nextImageIndex)
+	img := imageLoader.getImage(nextImageIndex)
 	fmt.Println("Time to decode: ", time.Now().Sub(start), imageLoader.listOfFiles[imageLoader.currentIndex])
 	return img
 }
 
-func PeekPreviousImage(imageLoader *ImageLoader) *RayImgImage {
+func (imageLoader *ImageLoader) PeekPreviousImage() *RayImgImage {
 	previousImageIndex := imageLoader.currentIndex - 1
 	if previousImageIndex <= 0 {
 		previousImageIndex = len(imageLoader.listOfFiles) - 1
 	}
-	return getImage(imageLoader, previousImageIndex)
+	return imageLoader.getImage(previousImageIndex)
 }

--- a/internal/imageloader/imageloader.go
+++ b/internal/imageloader/imageloader.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davidbyttow/govips/v2/vips"
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
@@ -29,13 +28,6 @@ func New(listOfFiles []string, screenWidth int32, screenHeight int32) *ImageLoad
 	imageLoader.screenHeight = screenHeight
 
 	imageLoader.cacheDirectory, imageLoader.cacheImages = os.LookupEnv("CACHE_DIR")
-
-	vips.LoggingSettings(nil, vips.LogLevelWarning)
-	vipsConfig := vips.Config{}
-	// disable vips cache, we aren't doing/redoing many operations in a row
-	// Also, i've seen rayimg get OOM-killed, so less memory use is better
-	vipsConfig.MaxCacheSize = 0
-	vips.Startup(&vipsConfig)
 
 	return &imageLoader
 }

--- a/internal/imageloader/imageloading.go
+++ b/internal/imageloader/imageloading.go
@@ -177,6 +177,7 @@ func imageRefToRlImage(imageRef *vips.ImageRef) (*rl.Image, error) {
 	} else {
 		image = rl.NewImage(imageBytes, int32(imageRef.Width()), int32(imageRef.Height()), 1, rl.UncompressedR8g8b8)
 	}
+	imageRef.Close()
 	return image, nil
 }
 

--- a/internal/imageloader/imageloading.go
+++ b/internal/imageloader/imageloading.go
@@ -12,7 +12,7 @@ import (
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
-func getImage(imageLoader *ImageLoader, index int) *RayImgImage {
+func (imageLoader *ImageLoader) getImage(index int) *RayImgImage {
 	// unlikely, but could happen if there are a lot of corrupt images...
 	if index >= len(imageLoader.listOfFiles) {
 		index = 0
@@ -22,8 +22,8 @@ func getImage(imageLoader *ImageLoader, index int) *RayImgImage {
 	currentFile := imageLoader.listOfFiles[index]
 	if _, err := os.Stat(currentFile); errors.Is(err, os.ErrNotExist) {
 		fmt.Println("WARNING: File does not exist", currentFile, ". Skipping for now - error: ", err.Error())
-		deleteImageAtIndex(imageLoader, index)
-		return getImage(imageLoader, index)
+		imageLoader.deleteImageAtIndex(index)
+		return imageLoader.getImage(index)
 	}
 
 	extension := strings.ToLower(currentFile[strings.LastIndex(currentFile, ".")+1:])
@@ -34,23 +34,23 @@ func getImage(imageLoader *ImageLoader, index int) *RayImgImage {
 		r, err := os.Open(currentFile)
 		if err != nil {
 			fmt.Println("WARNING: Unable to open file", currentFile, ". Skipping for now - error: ", err.Error())
-			deleteImageAtIndex(imageLoader, index)
-			return getImage(imageLoader, index)
+			imageLoader.deleteImageAtIndex(index)
+			return imageLoader.getImage(index)
 		}
 		defer r.Close()
 
 		err = loadGif(r, currentFile, imageData)
 		if err != nil {
 			fmt.Println("WARNING: Unable to decode image", currentFile, ". Skipping for now - error: ", err.Error())
-			deleteImageAtIndex(imageLoader, index)
-			return getImage(imageLoader, index)
+			imageLoader.deleteImageAtIndex(index)
+			return imageLoader.getImage(index)
 		}
 	} else {
-		texture, err := loadImageByType(imageLoader, currentFile, extension)
+		texture, err := imageLoader.loadImageByType(currentFile, extension)
 		if err != nil {
 			fmt.Println(err)
-			deleteImageAtIndex(imageLoader, index)
-			return getImage(imageLoader, index)
+			imageLoader.deleteImageAtIndex(index)
+			return imageLoader.getImage(index)
 		}
 		imageData.ImageData = texture
 	}
@@ -58,7 +58,7 @@ func getImage(imageLoader *ImageLoader, index int) *RayImgImage {
 	return imageData
 }
 
-func loadImageByType(imageLoader *ImageLoader, currentFile string, extension string) (*rl.Texture2D, error) {
+func (imageLoader *ImageLoader) loadImageByType(currentFile string, extension string) (*rl.Texture2D, error) {
 
 	if imageLoader.cacheImages {
 		_, cacheFile := getCacheFileLocation(imageLoader.cacheDirectory, currentFile)
@@ -84,15 +84,15 @@ func loadImageByType(imageLoader *ImageLoader, currentFile string, extension str
 	case "bmp":
 		fallthrough
 	case "qoi":
-		image, shouldCache = loadRaylib(currentFile, imageLoader)
+		image, shouldCache = imageLoader.loadRaylib(currentFile)
 		loadedViaRaylib = true
 		// TODO: get raylib error?
 
 	case "svg":
-		image, shouldCache, err = loadSvg(currentFile, imageLoader)
+		image, shouldCache, err = imageLoader.loadSvg(currentFile)
 
 	default:
-		image, shouldCache, err = loadVips(currentFile, imageLoader)
+		image, shouldCache, err = imageLoader.loadVips(currentFile)
 		if err != nil {
 			errorString := "WARNING: Unable to open image " + currentFile + ". Skipping for now - error: " + err.Error()
 			return nil, errors.New(errorString)
@@ -111,7 +111,7 @@ func loadImageByType(imageLoader *ImageLoader, currentFile string, extension str
 	return &texture, nil
 }
 
-func loadRaylib(filename string, imageLoader *ImageLoader) (*rl.Image, bool) {
+func (imageLoader *ImageLoader) loadRaylib(filename string) (*rl.Image, bool) {
 	image := rl.LoadImage(filename)
 	width := image.Width
 	height := image.Height
@@ -128,7 +128,7 @@ func loadRaylib(filename string, imageLoader *ImageLoader) (*rl.Image, bool) {
 	return image, false
 }
 
-func loadVips(filename string, imageLoader *ImageLoader) (*rl.Image, bool, error) {
+func (imageLoader *ImageLoader) loadVips(filename string) (*rl.Image, bool, error) {
 	imageRef, err := vips.NewImageFromFile(filename)
 	if err != nil {
 		return nil, false, err
@@ -181,7 +181,7 @@ func imageRefToRlImage(imageRef *vips.ImageRef) (*rl.Image, error) {
 	return image, nil
 }
 
-func loadSvg(filename string, imageLoader *ImageLoader) (*rl.Image, bool, error) {
+func (imageLoader *ImageLoader) loadSvg(filename string) (*rl.Image, bool, error) {
 	imageRef, err := vips.NewThumbnailFromFile(filename, int(imageLoader.screenWidth), int(imageLoader.screenHeight), vips.InterestingNone)
 	if imageRef.ColorSpace() != vips.InterpretationSRGB {
 		err = imageRef.ToColorSpace(vips.InterpretationSRGB)


### PR DESCRIPTION
I was getting OOM-killed when testing on a Raspberry Pi, so in an attempt to reduce memory:
- Disable vips cache
- Manually close imageref after getting the bytes
- Disabled gifs (will re-enable via #3)

Other smaller changes:
- Updated README with display and sample `slide_settings.ini`
- Moved vips startup/shutdown into main
- Reorganized some golang code (because I'm still new to golang... >.<)