### PR TITLE
will now check on rpi for fbset and can now set rotation

### DIFF
--- a/build/rayimg/imageloader/imageloader.lua
+++ b/build/rayimg/imageloader/imageloader.lua
@@ -8,6 +8,8 @@ local rl = require("rayimg.raylib")
 local path = require("path")
 local fs = require("path.fs")
 
+local ROTATION = tonumber(os.getenv("ROTATION")) or 0
+
 local image_loaders = {
    [".avif"] = vips_image.load_image_and_downsize,
    [".bmp"] = raylib_image.load_image_and_downsize,
@@ -37,14 +39,35 @@ local image_loaders = {
 
 
 
+
 local ImageLoader = {}
 
 
 
 
 local function calculate_scale_and_position(screen_width, screen_height, texture)
-   local scale = math.min(screen_width / texture.width, screen_height / texture.height)
-   local position = rl.NewVector2((screen_width / 2) - (texture.width / 2 * scale), (screen_height / 2) - (texture.height / 2 * scale))
+
+   local scale
+   local position
+
+   if ROTATION == 90 then
+      scale = math.min(screen_height / texture.width, screen_width / texture.height)
+      position = rl.NewVector2((screen_width / 2) + (texture.height / 2 * scale), (screen_height / 2) - (texture.width / 2 * scale))
+
+   elseif ROTATION == 180 then
+      scale = math.min(screen_width / texture.width, screen_height / texture.height)
+      position = rl.NewVector2((screen_width / 2) + (texture.width / 2 * scale), (screen_height / 2) + (texture.height / 2 * scale))
+
+   elseif ROTATION == 270 then
+      scale = math.min(screen_height / texture.width, screen_width / texture.height)
+      position = rl.NewVector2((screen_width / 2) - (texture.height / 2 * scale), (screen_height / 2) + (texture.width / 2 * scale))
+
+   else
+      scale = math.min(screen_width / texture.width, screen_height / texture.height)
+      position = rl.NewVector2((screen_width / 2) - (texture.width / 2 * scale), (screen_height / 2) - (texture.height / 2 * scale))
+
+   end
+
    return scale, position
 end
 
@@ -83,7 +106,11 @@ ImageLoader.load_image = function(filepath, screen_width, screen_height, cache_d
 
       local file_extension = path.suffix(filepath)
       local start = os.clock()
-      loaded_image = image_loaders[file_extension](filepath, screen_width, screen_height)
+      if ROTATION == 0 or ROTATION == 180 then
+         loaded_image = image_loaders[file_extension](filepath, screen_width, screen_height)
+      elseif ROTATION == 90 or ROTATION == 270 then
+         loaded_image = image_loaders[file_extension](filepath, screen_height, screen_width)
+      end
       print("Time to load image", filepath, (os.clock() - start) * 1000)
       texture = rl.LoadTextureFromImage(loaded_image.image)
 

--- a/build/rayimg/main.lua
+++ b/build/rayimg/main.lua
@@ -6,8 +6,10 @@ local ImageHandler = require("rayimg.imageloader.imagehandler")
 local ImageLoader = require("rayimg.imageloader.imageloader")
 local imageinterface = require("rayimg.imageinterface")
 local get_screen_resolution = require("rayimg.screen")
-
 local path = require("path")
+
+local ROTATION = tonumber(os.getenv("ROTATION")) or 0
+
 local rayimg_location = package.searchpath("rayimg.main", package.path)
 local rayimg_dir = path.parent(rayimg_location)
 local font_location = path.abs(rayimg_dir, "NotoSans-Regular.ttf")
@@ -23,6 +25,9 @@ local screen_width, screen_height = get_screen_resolution()
 local function load_app()
    local args = arguments.get_settings()
    local files = get_list_files(args)
+   if not (ROTATION == 0 or ROTATION == 90 or ROTATION == 180 or ROTATION == 270) then
+      error("ROTATION environment variable must be either 0, 90, 180, or 270. It is currently: " .. ROTATION)
+   end
    local image_handler = ImageHandler.new(files, screen_width, screen_height)
 
    return args, image_handler
@@ -32,6 +37,7 @@ local function display_error(error_message)
    rl.init_window(screen_width, screen_height, "rayimg - ERROR")
    local font = rl.LoadFont(font_location)
    local font_position = rl.NewVector2(10, 10)
+   rl.SetTextureFilter(font.texture, rl.FilterBilinear)
    local short_error = error_message:match(":%d+%: (.-)\n")
    while not rl.WindowShouldClose() do
       rl.BeginDrawing()
@@ -57,6 +63,7 @@ rl.init_window(screen_width, screen_height, "rayimg")
 local font = rl.LoadFont(font_location)
 local fontSize = 48
 local fontPosition = rl.NewVector2(20, screen_height - fontSize - 10)
+rl.SetTextureFilter(font.texture, rl.FilterBilinear)
 
 local loaded_texture = image_handler:get_current_image()
 local next_texture
@@ -95,7 +102,7 @@ end
 local function drawSingleImage()
    rl.BeginDrawing()
    rl.ClearBackground(rl.BLACK)
-   rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, 0, loaded_texture.scale, rl.WHITE)
+   rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, ROTATION, loaded_texture.scale, rl.WHITE)
    drawText()
    rl.EndDrawing()
 end
@@ -130,8 +137,8 @@ while not rl.WindowShouldClose() do
 
       rl.BeginDrawing()
       rl.ClearBackground(rl.BLACK)
-      rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, 0, loaded_texture.scale, rl.NewColor(255, 255, 255, 255 - transition_opacity))
-      rl.DrawTextureEx(next_texture.texture, next_texture.position, 0, next_texture.scale, rl.NewColor(255, 255, 255, transition_opacity))
+      rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, ROTATION, loaded_texture.scale, rl.NewColor(255, 255, 255, 255 - transition_opacity))
+      rl.DrawTextureEx(next_texture.texture, next_texture.position, ROTATION, next_texture.scale, rl.NewColor(255, 255, 255, transition_opacity))
       drawText()
       rl.EndDrawing()
 

--- a/build/rayimg/raylib.lua
+++ b/build/rayimg/raylib.lua
@@ -203,6 +203,7 @@ local rl = ffi.load("raylib")
 
 
 
+
 local raylib = {}
 
 

--- a/build/rayimg/screen.lua
+++ b/build/rayimg/screen.lua
@@ -1,12 +1,26 @@
-local function get_screen_resolution()
-   local file = io.popen('fbset; echo $?')
-   local output = file:read('*all')
-   file:close()
 
-   local return_code = output:sub(-2, -2)
-   if return_code ~= "0" then
+local function run_process(command)
+   local file = io.popen(command .. '; echo $?')
+   local output = file:read('*all')
+   local rc_start, rc_end = output:find("(%d+)\n$")
+   local return_code = output:sub(rc_start, rc_end)
+   file:close()
+   return output:sub(0, rc_start - 1), tonumber(return_code)
+end
+
+local function get_screen_resolution()
+
+
+   local output, return_code = run_process("which fbset")
+   if return_code ~= 0 then
 
       return 960, 540
+   end
+
+   output, return_code = run_process("fbset")
+
+   if return_code ~= 0 then
+      error("fbset return code: " .. return_code .. ". Unable to determine screen resolution")
    end
 
    local width, height = output:match("mode \"(%d+)x(%d+)")

--- a/src/rayimg/imageloader/imageloader.tl
+++ b/src/rayimg/imageloader/imageloader.tl
@@ -8,6 +8,8 @@ local rl = require("rayimg.raylib")
 local path = require("path")
 local fs = require("path.fs")
 
+local ROTATION = tonumber(os.getenv("ROTATION")) or 0
+
 local image_loaders: {string:function(string, integer, integer): imageinterface.LoadedImage} = {
     [".avif"] = vips_image.load_image_and_downsize,
     [".bmp"] = raylib_image.load_image_and_downsize,
@@ -31,10 +33,11 @@ local record LoadedTexture
     -- ideally it shouldn't be accessed directly
     image: imageinterface.LoadedImage
     texture: rl.Texture2D
-    position: rl.Vector2
     filename: string
     caption: string
+
     scale: number
+    position: rl.Vector2
 end
 
 local record ImageLoader
@@ -43,8 +46,28 @@ local record ImageLoader
 end
 
 local function calculate_scale_and_position(screen_width: integer, screen_height: integer, texture: rl.Texture2D): number, rl.Vector2
-    local scale = math.min(screen_width/texture.width, screen_height/texture.height)
-    local position = rl.NewVector2( (screen_width/2) - (texture.width/2 * scale), (screen_height/2) - (texture.height/2 * scale))
+    
+    local scale: number
+    local position: rl.Vector2
+
+    if ROTATION == 90 then
+        scale = math.min(screen_height/texture.width, screen_width/texture.height)
+        position = rl.NewVector2( (screen_width/2) + (texture.height/2 * scale), (screen_height/2) - (texture.width/2 * scale))
+
+    elseif ROTATION == 180 then
+        scale = math.min(screen_width/texture.width, screen_height/texture.height)
+        position = rl.NewVector2( (screen_width/2) + (texture.width/2 * scale), (screen_height/2) + (texture.height/2 * scale))
+
+    elseif ROTATION == 270 then
+        scale = math.min(screen_height/texture.width, screen_width/texture.height)
+        position = rl.NewVector2( (screen_width/2) - (texture.height/2 * scale), (screen_height/2) + (texture.width/2 * scale))
+
+    else
+        scale = math.min(screen_width/texture.width, screen_height/texture.height)
+        position = rl.NewVector2( (screen_width/2) - (texture.width/2 * scale), (screen_height/2) - (texture.height/2 * scale))
+
+    end
+
     return scale, position
 end
 
@@ -83,7 +106,11 @@ ImageLoader.load_image = function(filepath: string, screen_width: integer, scree
 
         local file_extension = path.suffix(filepath)
         local start = os.clock()
-        loaded_image = image_loaders[file_extension](filepath, screen_width, screen_height)
+        if ROTATION == 0 or ROTATION == 180 then
+            loaded_image = image_loaders[file_extension](filepath, screen_width, screen_height)
+        elseif ROTATION == 90 or ROTATION == 270 then
+            loaded_image = image_loaders[file_extension](filepath, screen_height, screen_width)
+        end
         print("Time to load image", filepath, (os.clock() - start) * 1000)
         texture = rl.LoadTextureFromImage(loaded_image.image)
         

--- a/src/rayimg/main.tl
+++ b/src/rayimg/main.tl
@@ -6,8 +6,10 @@ local ImageHandler = require("rayimg.imageloader.imagehandler")
 local ImageLoader = require("rayimg.imageloader.imageloader")
 local imageinterface = require("rayimg.imageinterface")
 local get_screen_resolution = require("rayimg.screen")
-
 local path = require("path")
+
+local ROTATION = tonumber(os.getenv("ROTATION")) or 0
+
 local rayimg_location = package.searchpath("rayimg.main", package.path)
 local rayimg_dir = path.parent(rayimg_location)
 local font_location = path.abs(rayimg_dir, "NotoSans-Regular.ttf")
@@ -23,6 +25,9 @@ local screen_width, screen_height = get_screen_resolution()
 local function load_app(): arguments.SlideSettings, ImageHandler
     local args = arguments.get_settings()
     local files = get_list_files(args)
+    if not (ROTATION == 0 or ROTATION == 90 or ROTATION == 180 or ROTATION == 270) then
+        error("ROTATION environment variable must be either 0, 90, 180, or 270. It is currently: " .. ROTATION)
+    end
     local image_handler = ImageHandler.new(files, screen_width, screen_height)
 
     return args, image_handler
@@ -32,6 +37,7 @@ local function display_error(error_message: string)
     rl.init_window(screen_width, screen_height, "rayimg - ERROR")
     local font = rl.LoadFont(font_location)
     local font_position = rl.NewVector2(10, 10)
+    rl.SetTextureFilter(font.texture, rl.FilterBilinear)
     local short_error = error_message:match(":%d+%: (.-)\n")
     while not rl.WindowShouldClose() do
         rl.BeginDrawing()
@@ -57,6 +63,7 @@ rl.init_window(screen_width, screen_height, "rayimg")
 local font = rl.LoadFont(font_location)
 local fontSize = 48
 local fontPosition = rl.NewVector2(20, screen_height-fontSize-10)
+rl.SetTextureFilter(font.texture, rl.FilterBilinear)
 
 local loaded_texture = image_handler:get_current_image()
 local next_texture: ImageLoader.LoadedTexture
@@ -95,7 +102,7 @@ end
 local function drawSingleImage()
     rl.BeginDrawing()
     rl.ClearBackground(rl.BLACK)
-    rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, 0, loaded_texture.scale, rl.WHITE)
+    rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, ROTATION, loaded_texture.scale, rl.WHITE)
     drawText()
     rl.EndDrawing()
 end
@@ -130,8 +137,8 @@ while not rl.WindowShouldClose() do
 
         rl.BeginDrawing()
         rl.ClearBackground(rl.BLACK)
-        rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, 0, loaded_texture.scale, rl.NewColor(255, 255, 255, 255 - transition_opacity))
-        rl.DrawTextureEx(next_texture.texture, next_texture.position, 0, next_texture.scale, rl.NewColor(255, 255, 255, transition_opacity))
+        rl.DrawTextureEx(loaded_texture.texture, loaded_texture.position, ROTATION, loaded_texture.scale, rl.NewColor(255, 255, 255, 255 - transition_opacity))
+        rl.DrawTextureEx(next_texture.texture, next_texture.position, ROTATION, next_texture.scale, rl.NewColor(255, 255, 255, transition_opacity))
         drawText()
         rl.EndDrawing()
 

--- a/src/rayimg/raylib.tl
+++ b/src/rayimg/raylib.tl
@@ -181,6 +181,7 @@ local record Font
     baseSize: integer
     glyphCount: integer
     glyphPadding: integer
+    texture: Texture2D
 end
 
 local record Texture2D

--- a/src/rayimg/screen.tl
+++ b/src/rayimg/screen.tl
@@ -1,12 +1,26 @@
-local function get_screen_resolution(): integer, integer
-    local file = io.popen('fbset; echo $?')
+-- quick and a little dirty, but it gets the job done for what we need!
+local function run_process(command: string): string, integer
+    local file = io.popen(command .. '; echo $?')
     local output = file:read('*all')
+    local rc_start, rc_end = output:find("(%d+)\n$")
+    local return_code = output:sub(rc_start, rc_end)
     file:close()
+    return output:sub(0, rc_start - 1), tonumber(return_code) as integer
+end
 
-    local return_code = output:sub(-2, -2)
-    if return_code ~= "0" then
-        -- used for development
+local function get_screen_resolution(): integer, integer
+    -- honestly not the best way to check if we're on a pi, 
+    -- I would love if we could get back the build_platform from raylib
+    local output, return_code = run_process("which fbset")
+    if return_code ~= 0 then
+        -- not on a pi, assuming development, using .5 of 1920x1080
         return 960, 540
+    end
+
+    output, return_code = run_process("fbset")
+
+    if return_code ~= 0 then
+        error("fbset return code: " .. return_code .. ". Unable to determine screen resolution")
     end
 
     local width, height = output:match("mode \"(%d+)x(%d+)")


### PR DESCRIPTION
- [x] Check if on a Pi by looking for `fbset` and erroring out accordingly
  - This resulted in the PiSlide service thinking it was a clean shutdown. Also resolved on the service side by setting the restart policy to `always`.
- [x] Allow screen rotations